### PR TITLE
Apply policy for atomist/sdm-base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM atomist/sdm-base:0.0.1
+FROM atomist/sdm-base:0.0.4
 
 RUN apt-get update && apt-get install -y \
         openjdk-8-jdk


### PR DESCRIPTION
Apply policy `docker-base-image::atomist/sdm-base`:

_Docker base image_
```atomist/sdm-base (0.0.4)```

[fingerprint:docker-base-image::atomist/sdm-base=5c8fcd7b45dca22cb793715c93fe54bc6244a104277b7a0fd7cc9f1f1263fe1a]

---
<details>
  <summary><img src="https://images.atomist.com/logo/atomist-color-mark-small.png" height="20" valign="bottom"/>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code>
</details>